### PR TITLE
minor changes to work with PySDM==2.21 and matlab 2023b

### DIFF
--- a/drops_py.m
+++ b/drops_py.m
@@ -134,7 +134,7 @@ function [output] = drops_py(input)
     S_max = -1;
     for i = 1:input.nt
         try
-            particulator.run(int32(1));
+            particulator.run(int32(i));
         catch e
             e.message
             output = struct('N_act', nan, 'S_max', nan);


### PR DESCRIPTION
Summary of changes: 
 - modifications of keywords, to match changes which took place in PySDM.
 - Smax ratio was being output by drops_py.m, changed to Smax to reflect keyword.
 - matlab needed some arrays to be specified as type double in a slightly different way.